### PR TITLE
Add validations to single-stroke lessons and update longest, single-stroke briefs lesson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ validate-lessons: lessons
 	@$(CLI) validate-lessons
 
 # build-everything
-build-everything: typey-type-dict intermediate-standard-dict copy-dictionaries lessons lesson-index build-recommendations-courses collect-misstrokes lint-and-test
+build-everything: typey-type-dict intermediate-standard-dict copy-dictionaries lessons lesson-index build-recommendations-courses collect-misstrokes lint-and-test validate-lessons
 
 # sync-typey-type-data
 .PHONY: sync-typey-type-data

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,9 @@ tmp/make/lint-and-test.timestamp: build/index.js $(ALL_TS_FILES)
 	@mkdir -p tmp/make/
 	@touch tmp/make/lint-and-test.timestamp
 
+validate-lessons: lessons
+	@$(CLI) validate-lessons
+
 # build-everything
 build-everything: typey-type-dict intermediate-standard-dict copy-dictionaries lessons lesson-index build-recommendations-courses collect-misstrokes lint-and-test
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ yarn test
 yarn test:watch
 ```
 
+## Validate lessons
+
+```sh
+yarn dev validate-lessons
+```
+
 ## Build
 
 This cleans the `build` directory, compiles all the TypeScript to JavaScript and makes the `./build/index.js` executable:

--- a/faux-typey-type-data/lesson-source-data/drills/longest-words-with-single-stroke-briefs/words.txt
+++ b/faux-typey-type-data/lesson-source-data/drills/longest-words-with-single-stroke-briefs/words.txt
@@ -96,3 +96,5 @@ suppressives
 suppressants
 prerequisite
 preferential
+practitioner
+photographic

--- a/faux-typey-type-data/lesson-source-data/drills/longest-words-with-single-stroke-briefs/words.txt
+++ b/faux-typey-type-data/lesson-source-data/drills/longest-words-with-single-stroke-briefs/words.txt
@@ -56,7 +56,6 @@ disagreement
 satisfaction
 demonstrable
 partnerships
-disinfectant
 preponderate
 contributing
 neighborhood

--- a/faux-typey-type-data/lessons/drills/longest-words-with-single-stroke-briefs/lesson.txt
+++ b/faux-typey-type-data/lessons/drills/longest-words-with-single-stroke-briefs/lesson.txt
@@ -58,7 +58,6 @@ Longest Words with Single-Stroke Briefs
 'satisfaction': SAEBGS
 'demonstrable': STRABL
 'partnerships': PARPS
-'disinfectant': TKEUS/EUPB/TPEBG/TAPBT
 'preponderate': P-PT
 'contributing': KR-BGT
 'neighborhood': TPHAOD

--- a/faux-typey-type-data/lessons/drills/longest-words-with-single-stroke-briefs/lesson.txt
+++ b/faux-typey-type-data/lessons/drills/longest-words-with-single-stroke-briefs/lesson.txt
@@ -98,3 +98,5 @@ Longest Words with Single-Stroke Briefs
 'suppressants': SPREFPBTS
 'prerequisite': PR-R
 'preferential': PREFRL
+'practitioner': PRER
+'photographic': TPOEFBG

--- a/faux-typey-type-data/lessons/drills/longest-words-with-single-stroke-briefs/longest-words-with-single-stroke-briefs.json
+++ b/faux-typey-type-data/lessons/drills/longest-words-with-single-stroke-briefs/longest-words-with-single-stroke-briefs.json
@@ -57,7 +57,6 @@
 "SAEBGS": "satisfaction",
 "STRABL": "demonstrable",
 "PARPS": "partnerships",
-"TKEUS/EUPB/TPEBG/TAPBT": "disinfectant",
 "P-PT": "preponderate",
 "KR-BGT": "contributing",
 "TPHAOD": "neighborhood",

--- a/faux-typey-type-data/lessons/drills/longest-words-with-single-stroke-briefs/longest-words-with-single-stroke-briefs.json
+++ b/faux-typey-type-data/lessons/drills/longest-words-with-single-stroke-briefs/longest-words-with-single-stroke-briefs.json
@@ -96,5 +96,7 @@
 "SPREFS": "suppressives",
 "SPREFPBTS": "suppressants",
 "PR-R": "prerequisite",
-"PREFRL": "preferential"
+"PREFRL": "preferential",
+"PRER": "practitioner",
+"TPOEFBG": "photographic"
 }

--- a/faux-typey-type-data/lessons/lessonIndex.json
+++ b/faux-typey-type-data/lessons/lessonIndex.json
@@ -327,7 +327,7 @@
     "category": "Drills",
     "subcategory": "",
     "path": "/drills/longest-words-with-single-stroke-briefs/lesson.txt",
-    "wordCount": 99,
+    "wordCount": 100,
     "suggestedNext": "/drills/common-words/lesson.txt"
   },
   {

--- a/src/commands/validateLessons.ts
+++ b/src/commands/validateLessons.ts
@@ -6,39 +6,51 @@ import lessonTargetDataDir from "../consts/lessonTargetDataDir";
 import { StenoDictionary } from "src/shared/types";
 
 const longestSingleStrokeTarget = `${lessonTargetDataDir}/drills/longest-words-with-single-stroke-briefs/longest-words-with-single-stroke-briefs.json`;
+const singleStrokeTarget = `${lessonTargetDataDir}/drills/single-stroke-briefs/single-stroke-briefs.json`;
 
 /**
  * This command does common checks on lessons like single-stroke lessons should have only single-stroke outlines
  */
 const run = async () => {
-  const sourceContent = await fs.readFile(longestSingleStrokeTarget, "utf8");
+  const singleStrokeLessons = [singleStrokeTarget, longestSingleStrokeTarget];
 
-  let longestSingleStrokeLessonDict: null | StenoDictionary = null;
-  try {
-    longestSingleStrokeLessonDict = JSON.parse(sourceContent);
-  } catch (error) {
-    console.error(
-      `Error: there was an error parsing the source dictionaries index file. `,
-      error
-    );
-  }
+  singleStrokeLessons.forEach(async (singleStrokeLesson) => {
+    const sourceContent = await fs.readFile(singleStrokeLesson, "utf8");
 
-  if (longestSingleStrokeLessonDict === null) {
-    console.error("Longest single-stroke briefs lesson dictionary is null");
-    return;
-  }
-
-  for (const [outline, translation] of Object.entries(
-    longestSingleStrokeLessonDict
-  )) {
-    if (outline.includes("/")) {
-      throw new Error(
-        `❌ Longest Words with Single-Stroke Briefs lesson contains multi-stroke outline: ${outline}: ${translation}`
+    let dict: null | StenoDictionary = null;
+    try {
+      dict = JSON.parse(sourceContent);
+    } catch (error) {
+      console.error(
+        `Error: there was an error parsing the lesson file for validation. `,
+        error
       );
     }
-  }
 
-  console.log("✅ Lessons validated. Looks Good To Me!");
+    if (dict === null) {
+      console.error(
+        `Found null dictionary validating lesson: ${singleStrokeLesson}`
+      );
+
+      throw new Error(
+        `❌ Single-stroke lessons should have dictionary files to validate. `
+      );
+    }
+
+    for (const [outline, translation] of Object.entries(dict)) {
+      if (outline.includes("/")) {
+        const filename = singleStrokeLesson.replace(/.*\//, "");
+        console.error(
+          `❌ ${filename} contains multi-stroke outline: ${outline}: ${translation}`
+        );
+        throw new Error(
+          `❌ Single-stroke lessons should not have multi-stroke outlines. `
+        );
+      }
+    }
+  });
+
+  console.log("✅ Single-stroke lessons validated. Looks Good To Me!");
 };
 
 export default {

--- a/src/commands/validateLessons.ts
+++ b/src/commands/validateLessons.ts
@@ -1,0 +1,46 @@
+"use strict";
+
+import fs from "node:fs/promises";
+
+import lessonTargetDataDir from "../consts/lessonTargetDataDir";
+import { StenoDictionary } from "src/shared/types";
+
+const longestSingleStrokeTarget = `${lessonTargetDataDir}/drills/longest-words-with-single-stroke-briefs/longest-words-with-single-stroke-briefs.json`;
+
+/**
+ * This command does common checks on lessons like single-stroke lessons should have only single-stroke outlines
+ */
+const run = async () => {
+  const sourceContent = await fs.readFile(longestSingleStrokeTarget, "utf8");
+
+  let longestSingleStrokeLessonDict: null | StenoDictionary = null;
+  try {
+    longestSingleStrokeLessonDict = JSON.parse(sourceContent);
+  } catch (error) {
+    console.error(
+      `Error: there was an error parsing the source dictionaries index file. `,
+      error
+    );
+  }
+
+  if (longestSingleStrokeLessonDict === null) {
+    console.error("Longest single-stroke briefs lesson dictionary is null");
+    return;
+  }
+
+  for (const [outline, translation] of Object.entries(
+    longestSingleStrokeLessonDict
+  )) {
+    if (outline.includes("/")) {
+      throw new Error(
+        `❌ Longest Words with Single-Stroke Briefs lesson contains multi-stroke outline: ${outline}: ${translation}`
+      );
+    }
+  }
+
+  console.log("✅ Lessons validated. Looks Good To Me!");
+};
+
+export default {
+  run,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 import buildLesson from "./commands/buildLesson";
 import buildLessonIndex from "./commands/buildLessonIndex";
 import copyDictionaries from "./commands/copyDictionaries";
+import validateLessons from "./commands/validateLessons";
 import buildRecommendationsCourses from "./commands/buildRecommendationsCourses";
 import buildTypeyTypeDictionary from "./commands/buildTypeyTypeDictionary";
 import addNewRule from "./commands/addNewRule";
@@ -58,6 +59,13 @@ async function main() {
     .description("Scaffolds files for new rules for fundamental lessons")
     .requiredOption("--rule <ruleName>", "camelCase rule name")
     .action(addNewRule.run);
+
+  program
+    .command("validate-lessons")
+    .description(
+      "Runs basic checks on lesson files to make sure they are as expected"
+    )
+    .action(validateLessons.run);
 
   program
     .command("split-lesson-index", { hidden: true })


### PR DESCRIPTION
This PR:

- Adds `validate-lessons` command to validate that the single-stroke lessons indeed have only single-stroke outlines
- Removes `disinfectant` from longest, single-stroke briefs lesson. `TKEPBGT` used to be "disinfectant" in original Plover dictionary but it's since been replaced with "denting", leaving only the multi-stroke outline for disinfectant `TKEUS/EUPB/TPEBG/TAPBT`.
- Adds 2 new words to longest, single-stroke briefs lesson to bring it back to 100 words.

Thanks to @YannCebron for Typey Type feedback about the "disinfectant" entry.