### PR TITLE
Check for duplication in standard set

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ To **collect misstrokes** into `misstrokes.json`:
 time make collect-misstrokes
 ```
 
+## Other one-off commands
+
+To check for outlines that are duplicated across Typey Type dictionaries:
+
+```sh
+yarn dev help check-duplicate-outlines
+yarn dev check-duplicate-outlines
+yarn dev check-duplicate-outlines --unique-translations
+```
+
 ## Debugging
 
 While you can run CLI commands individually, for lessons, just use `make`. If you want to run a command though, do this:

--- a/src/commands/checkDuplicateOutlines.ts
+++ b/src/commands/checkDuplicateOutlines.ts
@@ -1,0 +1,67 @@
+"use strict";
+
+import fs from "node:fs/promises";
+
+import standardDictionarySet from "../consts/standardDictionarySet.json";
+import standardDictionariesDir from "../consts/standardDictionariesDir";
+import zipDictNameAndContents from "../utils/zipDictNameAndContents";
+import type { StenoDictionary } from "src/shared/types";
+
+/**
+ * This command checks for duplicate outlines in the standard Typey Type dictionaries.
+ *
+ * - It reads all of the outlines in all of the dictionaries
+ * - It gathers up duplicate outlines
+ * - It shows results as an outline and which dictionaries it appears in
+ */
+const run = async () => {
+  console.log("Checking duplicate outlines…");
+
+  const standardDicts: StenoDictionary[] = await Promise.all(
+    standardDictionarySet
+      .filter((name) => name !== "top-10000-project-gutenberg-words.json")
+      .map(async (dictFile: string) => {
+        const dict = await fs.readFile(
+          `${standardDictionariesDir}/${dictFile}`,
+          "utf8"
+        );
+        return JSON.parse(dict);
+      })
+  ).catch((error) => {
+    throw new Error(
+      `There was an error reading the standard Typey Type dictionary set. ${error}`
+    );
+  });
+  const zippedDictionariesNamesAndContents = zipDictNameAndContents(
+    standardDictionarySet.filter(
+      (name) => name !== "top-10000-project-gutenberg-words.json"
+    ),
+    standardDicts
+  );
+
+  const seen = new Map();
+
+  for (const [dictName, dict] of zippedDictionariesNamesAndContents) {
+    for (const [outline] of Object.entries(dict)) {
+      if (seen.get(outline)) {
+        seen.set(outline, [...seen.get(outline), dictName]);
+      } else {
+        seen.set(outline, [dictName]);
+      }
+    }
+  }
+
+  const duplicates = new Map();
+  for (const [outline, dictNames] of seen) {
+    if (dictNames.length > 1) {
+      duplicates.set(outline, dictNames);
+    }
+  }
+
+  console.log("📣 Duplicates…");
+  console.log(duplicates);
+};
+
+export default {
+  run,
+};

--- a/src/commands/checkDuplicateOutlines.ts
+++ b/src/commands/checkDuplicateOutlines.ts
@@ -18,6 +18,7 @@ type Duplicates = Map<
 
 const ignoreExpectedDuplicateDictionaries = [
   "top-10000-project-gutenberg-words.json",
+  "punctuation-unspaced.json",
 ];
 
 /**

--- a/src/commands/checkDuplicateOutlines.ts
+++ b/src/commands/checkDuplicateOutlines.ts
@@ -16,6 +16,10 @@ type Duplicates = Map<
   { dictName: DictName; translation: Translation }[]
 >;
 
+const ignoreExpectedDuplicateDictionaries = [
+  "top-10000-project-gutenberg-words.json",
+];
+
 /**
  * This command checks for duplicate outlines in the standard Typey Type dictionaries.
  *
@@ -28,7 +32,7 @@ type Duplicates = Map<
 const run = async (options: Options) => {
   const standardDicts: StenoDictionary[] = await Promise.all(
     standardDictionarySet
-      .filter((name) => name !== "top-10000-project-gutenberg-words.json")
+      .filter((name) => !ignoreExpectedDuplicateDictionaries.includes(name))
       .map(async (dictFile: string) => {
         const dict = await fs.readFile(
           `${standardDictionariesDir}/${dictFile}`,
@@ -43,7 +47,7 @@ const run = async (options: Options) => {
   });
   const zippedDictionariesNamesAndContents = zipDictNameAndContents(
     standardDictionarySet.filter(
-      (name) => name !== "top-10000-project-gutenberg-words.json"
+      (name) => !ignoreExpectedDuplicateDictionaries.includes(name)
     ),
     standardDicts
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,10 @@ async function main() {
   program
     .command("check-duplicate-outlines")
     .description("Checks for outlines duplicated across dictionaries")
+    .option(
+      "-u, --unique-translations",
+      "show only duplicate outlines with differing translations"
+    )
     .action(checkDuplicateOutlines.run);
 
   await program.parseAsync(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 
 import buildLesson from "./commands/buildLesson";
 import buildLessonIndex from "./commands/buildLessonIndex";
+import checkDuplicateOutlines from "./commands/checkDuplicateOutlines";
 import copyDictionaries from "./commands/copyDictionaries";
 import validateLessons from "./commands/validateLessons";
 import buildRecommendationsCourses from "./commands/buildRecommendationsCourses";
@@ -87,6 +88,11 @@ async function main() {
     .command("split-lesson-index", { hidden: true })
     .description("Splits meta files from lesson index")
     .action(splitLessonIndex.run);
+
+  program
+    .command("check-duplicate-outlines")
+    .description("Checks for outlines duplicated across dictionaries")
+    .action(checkDuplicateOutlines.run);
 
   await program.parseAsync(process.argv);
 }


### PR DESCRIPTION
This PR adds helper commands to check for outlines that are duplicated across Typey Type dictionaries:

```sh
yarn dev check-duplicate-outlines
yarn dev check-duplicate-outlines --unique-translations
```